### PR TITLE
fix back-button related keyDown handler logic

### DIFF
--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -355,12 +355,16 @@ public class PythonActivity extends Activity {
     long lastBackClick = SystemClock.elapsedRealtime();
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        // Check if the key event was the Back button and if there's history
+        // Check if the key event was the Back button
         if ((keyCode == KeyEvent.KEYCODE_BACK)) {
+            // If there's some web history, go back
             if(mWebView.canGoBack()) {
                 mWebView.goBack();
                 return true;
             }
+            // Otherwise, if it's been a little while since the Back key was
+            // last pressed, register that it's been pressed and notify the
+            // user that pressing it again will close the app.
             if (SystemClock.elapsedRealtime() - lastBackClick > 2000){
                 lastBackClick = SystemClock.elapsedRealtime();
                 Toast.makeText(this, "Click again to close the app",
@@ -369,8 +373,9 @@ public class PythonActivity extends Activity {
             }
         }
         
-        // If it wasn't the Back key or there's no web page history, bubble up to the default
-        // system behavior (probably exit the activity)
+        // If it wasn't the Back key, or if the user tapped the Back key twice, 
+        // quickly and without web history, bubble up to the default system
+        // behavior (probably exit the activity)
         return super.onKeyDown(keyCode, event);
     }
 

--- a/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
+++ b/pythonforandroid/bootstraps/webview/build/src/main/java/org/kivy/android/PythonActivity.java
@@ -356,20 +356,21 @@ public class PythonActivity extends Activity {
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         // Check if the key event was the Back button and if there's history
-        if ((keyCode == KeyEvent.KEYCODE_BACK) && mWebView.canGoBack()) {
-            mWebView.goBack();
-            return true;
+        if ((keyCode == KeyEvent.KEYCODE_BACK)) {
+            if(mWebView.canGoBack()) {
+                mWebView.goBack();
+                return true;
+            }
+            if (SystemClock.elapsedRealtime() - lastBackClick > 2000){
+                lastBackClick = SystemClock.elapsedRealtime();
+                Toast.makeText(this, "Click again to close the app",
+                Toast.LENGTH_LONG).show();
+                return true;
+            }
         }
+        
         // If it wasn't the Back key or there's no web page history, bubble up to the default
         // system behavior (probably exit the activity)
-        if (SystemClock.elapsedRealtime() - lastBackClick > 2000){
-            lastBackClick = SystemClock.elapsedRealtime();
-            Toast.makeText(this, "Click again to close the app",
-            Toast.LENGTH_LONG).show();
-            return true;
-        }
-
-        lastBackClick = SystemClock.elapsedRealtime();
         return super.onKeyDown(keyCode, event);
     }
 


### PR DESCRIPTION
In my investigations of [this issue](https://github.com/learningequality/kolibri/issues/6890), I discovered that the explanation in the comments of the code modified in this PR didn't match the code itself.  Basically `keyDown` handler was treating all key presses as initial back button presses.

I've adjusted the code and the comments to something that seems logical to me.  That said, I tried testing this locally, but it's pretty late and I found that there's a lot of basic pew/python-for-android stuff I just don't know how to do, so I figured I might as well make a PR and see how it looks to you!